### PR TITLE
IsStackTrace

### DIFF
--- a/StackTraceParser.cs
+++ b/StackTraceParser.cs
@@ -119,6 +119,11 @@ namespace Elmah
                                                           Token(groups["line"], tokenSelector)));
         }
 
+        public static bool IsStackTrace(string text)
+        {
+            return !string.IsNullOrWhiteSpace(text) && Regex.IsMatch(text);
+        }
+
         static T Token<T>(Capture capture, Func<int, int, string, T> tokenSelector)
         {
             return tokenSelector(capture.Index, capture.Length, capture.Value);

--- a/StackTraceParserTests.cs
+++ b/StackTraceParserTests.cs
@@ -140,6 +140,30 @@ namespace Tests
             Assert.That(e.ParamName, Is.EqualTo("selector"));
         }
 
+        [Test]
+        public void IsStackTraceFalseOnNull()
+        {
+            Assert.That(StackTraceParser.IsStackTrace(null), Is.False);
+        }
+
+        [Test]
+        public void IsStackTraceFalseOnWhitespace()
+        {
+            Assert.That(StackTraceParser.IsStackTrace(" "), Is.False);
+        }
+
+        [Test]
+        public void IsStackTraceFalseOnNonStackTrace()
+        {
+            Assert.That(StackTraceParser.IsStackTrace("text"), Is.False);
+        }
+
+        [Test]
+        public void IsStackTraceTrueOnStackTrace()
+        {
+            Assert.That(StackTraceParser.IsStackTrace(DotNetStackTrace), Is.True);
+        }
+
         const string DotNetStackTrace = @"
             Elmah.TestException: This is a test exception that can be safely ignored.
                 at Elmah.ErrorLogPageFactory.FindHandler(String name) in C:\ELMAH\src\Elmah\ErrorLogPageFactory.cs:line 126


### PR DESCRIPTION
I've added the `IsStackTrace` method in my own code to utilize the regular expression to check if a string is a stacktrace or not, without actually hacing to convert the string into a stacktrace. Merge if you think it makes sense inside this project :smile:
